### PR TITLE
Remove slackSend steps since we are on jenkinsci now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     }
         post {
             always {
-                echo "--> ALWAYS: We are finished with ${currentBuild.fullDisplayName}"
+                echo "--> We are finished with ${currentBuild.fullDisplayName}"
                 junit testResults: 'target/surefire-reports/*.xml', keepLongStdio: true
                 archiveArtifacts "target/site/jacoco/jacoco.xml"
                 jacoco (
@@ -57,27 +57,12 @@ pipeline {
             }
             success {
                 echo "--> SUCCESS: ${currentBuild.fullDisplayName}"
-                slackSend(
-                    message: 'Successful build: currentBuild.fullDisplayName'
-                    color: ‘good’,
-                    channel: ‘#team-pipeline’
-                )
             }
             unstable {
                 echo "--> UNSTABLE: ${currentBuild.fullDisplayName}"
-                slackSend(
-                    message: 'Ustable build: currentBuild.fullDisplayName'
-                    color: ‘good’,
-                    channel: ‘#team-pipeline’
-                )
             }
             failure {
                 echo "--> FAILURE: ${currentBuild.fullDisplayName}"
-                slackSend(
-                    message: 'Failed build: currentBuild.fullDisplayName'
-                    color: ‘bad’,
-                    channel: ‘#team-pipeline’
-                )
             }
         }
 }


### PR DESCRIPTION
As described. Since this plugin isn't in the cloudbees organization anymore, I've removed the `slackSend` steps.